### PR TITLE
Rails template source gets cleared when compiled, so it causes deface to fail to return source

### DIFF
--- a/lib/deface/override.rb
+++ b/lib/deface/override.rb
@@ -161,7 +161,7 @@ module Deface
       elsif @args.key? :text
         @args[:text]
       end
-      erb.nil? ? @template_source : erb
+      erb || @template_source
     end
 
     def source_element


### PR DESCRIPTION
This keeps a copy of the source when first initialized. It returns this source in the event a refetch of the source returns nil. All 90 examples are green.
