### PR TITLE
Configure travis to test against versions of rails supported by the .gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - ree
+gemfile:
+  - gemfiles/rails3_0.gemfile
+  - gemfiles/rails3_1.gemfile
+  - gemfiles/rails3_2.gemfile

--- a/gemfiles/rails3_0.gemfile
+++ b/gemfiles/rails3_0.gemfile
@@ -1,0 +1,5 @@
+source :rubygems
+
+gem "rails", "~> 3.0.9"
+
+gemspec :path=>"../"

--- a/gemfiles/rails3_1.gemfile
+++ b/gemfiles/rails3_1.gemfile
@@ -1,0 +1,5 @@
+source :rubygems
+
+gem "rails", "~> 3.1.0"
+
+gemspec :path=>"../"

--- a/gemfiles/rails3_2.gemfile
+++ b/gemfiles/rails3_2.gemfile
@@ -1,0 +1,5 @@
+source :rubygems
+
+gem "rails", "~> 3.2.0"
+
+gemspec :path=>"../"


### PR DESCRIPTION
The deface.gemspec specifies all Rails versions >= 3.0.9, which means that Travis has only been testing against the latest version of rails. I created gemfiles for each version of Rails that's out that meets that rule. We should probably test against Rails edge as well.
