### PR TITLE
Adding move_top and move_bottom actions for overrides

### DIFF
--- a/lib/deface/applicator.rb
+++ b/lib/deface/applicator.rb
@@ -113,7 +113,14 @@ module Deface
                         match.set_attribute "data-erb-#{name}", match.attributes["data-erb-#{name}"].value.gsub(value.to_s, '').strip
                       end
                     end
-
+                  when :move_bottom
+                    destination = doc.css(override.destination)
+                    destination.children.after(match.clone(1))
+                    match.replace ""
+                  when :move_top
+                  destination = doc.css(override.destination)
+                  destination.children.before(match.clone(1))
+                  match.replace ""
                 end
 
               end

--- a/lib/deface/override.rb
+++ b/lib/deface/override.rb
@@ -9,7 +9,7 @@ module Deface
     attr_accessor :args
 
     @@_early = []
-    @@actions = [:remove, :replace, :replace_contents, :surround, :surround_contents, :insert_after, :insert_before, :insert_top, :insert_bottom, :set_attributes, :add_to_attributes, :remove_from_attributes]
+    @@actions = [:remove, :replace, :replace_contents, :surround, :surround_contents, :insert_after, :insert_before, :insert_top, :insert_bottom, :set_attributes, :add_to_attributes, :remove_from_attributes, :move_top, :move_bottom]
     @@sources = [:text, :erb, :haml, :partial, :template]
 
     # Initializes new override, you must supply only one Target, Action & Source
@@ -123,6 +123,10 @@ module Deface
 
     def name
       @args[:name]
+    end
+
+    def destination
+      @args[:to]
     end
 
     def sequence

--- a/spec/deface/applicator_spec.rb
+++ b/spec/deface/applicator_spec.rb
@@ -363,5 +363,23 @@ module Deface
       end
     end
 
+    describe "with a single move_bottom override" do
+      before { Deface::Override.new(:virtual_path => "posts/index", :name => "Posts#index", :move_bottom => "child", :to => "parent") }
+      let(:source) { '<child>move me</child><parent>destination</parent>' }
+
+      it "should return modified source, with element moved" do
+        Dummy.apply(source, {:virtual_path => "posts/index"}).should == "<parent>destination<child>move me</child></parent>"
+      end
+    end
+
+    describe "with a single move_top override" do
+      before { Deface::Override.new(:virtual_path => "posts/index", :name => "Posts#index", :move_top => "child", :to => "parent") }
+      let(:source) { '<child>move me</child><parent>destination</parent>' }
+
+      it "should return modified source, with element moved" do
+        Dummy.apply(source, {:virtual_path => "posts/index"}).should == "<parent><child>move me</child>destination</parent>"
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Hi,

I have added the actions :move_top and :move_bottom to override in order to move an existing element in to another defined in the same template. To define the destination I have added a the option :to to the override initializer. 

Example:

```
# app/views/templates/move.html.erb
<div class="target">Target</div>
<div class="destination">Destination</div>
```

   # app/overrides/move_target.rb
   Deface::Override.new(
     virtual_path: "templates/move", 
    move_bottom: ".target",
    to: ".destinaiton",
    name: 'move_target')

```
# Would produce the result...
<div class="destination">Destination<div class="target">Target</div></div>
```

Any thoughts?
