### PR TITLE
Add Caveat mentioning that the order in which extensions are added to yo...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -314,3 +314,5 @@ Deface uses the amazing Nokogiri library (and in turn libxml) for parsing HTML /
 2. Parsing will fail and result in invalid output if ERB blocks are responsible for closing an HTML tag that was opened normally, i.e. don't do this:
 
       &lt;div <%= ">" %>
+
+3. Gems or Spree Extensions that add overrides to your application will load them in the order they are added to your Gemfile.


### PR DESCRIPTION
...ur Gemfile matters.

A user was a bit confused on one of my extensions as to why the load order worked the way it did.  I thought there was some documentation on this, but it doesn't look like it after quickly browsing through the README and Spree Guides.

https://github.com/jdutil/spree_contact_us/issues/1#issuecomment-6566382
