### PR TITLE
Give DSL overrides unique names based on engine.

### DIFF
--- a/lib/deface/dsl/loader.rb
+++ b/lib/deface/dsl/loader.rb
@@ -16,6 +16,7 @@ module Deface
 
         File.open(filename) do |file|
           context_name = File.basename(filename).gsub('.deface', '')
+          context_name = Override.current_railtie.underscore + '_' + context_name if Override.current_railtie
 
           file_contents = file.read
 

--- a/spec/deface/dsl/loader_spec.rb
+++ b/spec/deface/dsl/loader_spec.rb
@@ -124,6 +124,14 @@ describe Deface::DSL::Loader do
       Deface::DSL::Loader.load(filename)
     end
 
+    it "should prepend the name of the override with the name of the railtie when loaded from an engine" do
+      File.stub(:open).and_yield(mock.as_null_object)
+
+      Deface::Override.current_railtie = 'SpreeEngine'
+      Deface::DSL::Context.should_receive(:new).with('spree_engine_assets').and_return(mock.as_null_object)
+      Deface::DSL::Loader.load('app/overrides/path/to/view/assets.html.erb.deface')
+    end
+
   end
 
   context '.register' do


### PR DESCRIPTION
Since DSL overrides loaded from engines and using the same paths/filenames default to having the same name, they would as a result redefine each other and only allow one to be active at any time.
This causes problems for Chili extensions which each come with a built in `assets.html.erb.deface` override for injecting stylesheets:

``` erb
<% # app/overrides/layouts/application/assets.html.erb.deface %>
<!-- insert_bottom 'head' -->
<%= stylesheet_link_tag 'chili_social/application' %>
<%= javascript_include_tag 'chili_social/application' %>
```

This commit gives the DSL overrides a unique name based on which railtie they were loaded from.
Let me know if there is something I've overlooked!
