### PR TITLE
Fixed "unbreakable" specs

### DIFF
--- a/spec/deface/dsl/context_spec.rb
+++ b/spec/deface/dsl/context_spec.rb
@@ -9,9 +9,7 @@ describe Deface::DSL::Context do
     subject { context = Deface::DSL::Context.new('sample_name') }
 
     def override_should_be_created_with(expected_hash)
-      Deface::Override.should_receive(:new).with(hash_including(
-        :name => 'sample_name'
-      ))
+      Deface::Override.should_receive(:new).with hash_including(expected_hash.reverse_merge(:name => 'sample_name'))
 
       subject.create_override
     end


### PR DESCRIPTION
"expected_hash" was being ignored so all specs would pass no matter what.

For example, when changing line 24 in context_spec from:

``` ruby
subject.virtual_path('test/path')
override_should_be_created_with(:virtual_path => 'test/path')
```

to

``` ruby
subject.virtual_path('different/path')
override_should_be_created_with(:virtual_path => 'test/path')
```

the test would still pass.
