### PR TITLE
fix HamlConverter to handle multi byte

### DIFF
--- a/spec/deface/haml_converter_spec.rb
+++ b/spec/deface/haml_converter_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 module Deface
@@ -83,6 +85,15 @@ module Deface
   %p
     = post.name").should == "<% @posts.each do |post| %><p>  <%= post.name %></p><% end %>"
 
+      end
+    end
+
+    describe "convert haml thant includes multi byte string to erb" do
+      before { Encoding.default_internal = 'UTF-8' }
+      after { Encoding.default_internal = nil }
+
+      it "should handle" do
+        haml_to_erb("%%strong.code#message ハロー、ワールド！".force_encoding('ASCII-8BIT')).should == "<strong class='code' id='message'>ハロー、ワールド！</strong>"
       end
     end
   end


### PR DESCRIPTION
When Encoding.default_internal is 'UTF-8' HamlConverter can't handle haml that include multi byte properly.
Haml source should be encoded to properly before compile like ActionView::Template doing.
This patch do it.
