### PR TITLE
moves precompile code into a class so it can be tested and extended

### DIFF
--- a/lib/deface.rb
+++ b/lib/deface.rb
@@ -34,6 +34,7 @@ require "deface/actions/remove_from_attributes"
 require "deface/matchers/element"
 require "deface/matchers/range"
 require "deface/environment"
+require "deface/precompiler"
 require "colorize"
 
 module Deface

--- a/lib/deface/precompiler.rb
+++ b/lib/deface/precompiler.rb
@@ -1,0 +1,33 @@
+module Deface
+  class Precompiler
+
+    extend Deface::TemplateHelper
+
+    def self.precompile
+      base_path = Rails.root.join("app/compiled_views")
+      # temporarily configures deface env and loads
+      # all overrides so we can precompile
+      unless Rails.application.config.deface.enabled
+        Rails.application.config.deface = Deface::Environment.new
+        Rails.application.config.deface.overrides.early_check
+        Rails.application.config.deface.overrides.load_all Rails.application
+      end
+
+      Rails.application.config.deface.overrides.all.each do |virtual_path,overrides|
+        template_path = base_path.join( "#{virtual_path}.html.erb")
+
+        FileUtils.mkdir_p template_path.dirname
+        begin
+          source = load_template_source(virtual_path.to_s, false, true)
+          if source.blank?
+            raise "Compiled source was blank for '#{virtual_path}'"
+          end
+          File.open(template_path, 'w') {|f| f.write source } 
+        rescue Exception => e
+          puts "Unable to precompile '#{virtual_path}' due to: "
+          puts e.message
+        end
+      end
+    end
+  end
+end

--- a/lib/deface/template_helper.rb
+++ b/lib/deface/template_helper.rb
@@ -1,7 +1,7 @@
 module Deface
   module TemplateHelper
 
-    # used to find source for a partial or template using virutal_path
+    # used to find source for a partial or template using virtual_path
     def load_template_source(virtual_path, partial, apply_overrides=true)
       parts = virtual_path.split("/")
       prefix = []

--- a/spec/assets/dummy_app/overrides/posts/precompileme/precompileme.html.erb.deface
+++ b/spec/assets/dummy_app/overrides/posts/precompileme/precompileme.html.erb.deface
@@ -1,0 +1,2 @@
+<!-- insert_bottom 'li' -->
+Added to li!

--- a/spec/assets/posts/precompileme.html.erb
+++ b/spec/assets/posts/precompileme.html.erb
@@ -1,0 +1,2 @@
+<p>I'm from shared/precompileme template</p>
+<%= "I've got ERB too" %>

--- a/spec/deface/precompiler_spec.rb
+++ b/spec/deface/precompiler_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module Deface
+
+  describe Precompiler do
+    include_context "mock Rails.application"
+
+    before do
+      # start with a clean file system
+      FileUtils.rm_rf('spec/dummy/app/compiled_views')
+      environment = Deface::Environment.new
+      overrides = Deface::Environment::Overrides.new
+      overrides.stub(:all => {}) # need to do this before creating an override
+      overrides.stub(:all => {"posts/precompileme".to_sym => {"precompileme".parameterize => Deface::Override.new(:virtual_path => "posts/precompileme", :name => "precompileme", :insert_bottom => 'li', :text => "Added to li!")}})
+      environment.stub(:overrides => overrides)
+
+      Rails.application.config.stub :deface => environment
+
+      #stub view paths to be local spec/assets directory
+      ActionController::Base.stub(:view_paths).and_return([File.join(File.dirname(__FILE__), '..', "assets")])
+
+      Precompiler.precompile()
+    end
+
+    after do
+      # cleanup the file system
+      FileUtils.rm_rf('spec/dummy/app/compiled_views')
+    end
+
+    it "writes precompiles the overrides" do
+
+      filename = 'spec/dummy/app/compiled_views/posts/precompileme.html.erb'
+
+      File.exists?(filename).should be_true
+
+      file = File.open(filename, "rb")
+      contents = file.read
+
+      contents.should =~ /precompile/
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,8 @@ shared_context "mock Rails" do
       Rails.application.config.stub :watchable_dirs => {}
     end
 
+    Rails.stub :root => Pathname.new('spec/dummy')
+
     Rails.stub :logger => mock('logger')
     Rails.logger.stub(:error)
     Rails.logger.stub(:warning)

--- a/tasks/precompile.rake
+++ b/tasks/precompile.rake
@@ -1,35 +1,10 @@
 require 'deface'
 
 namespace :deface do
-  include Deface::TemplateHelper
 
   desc "Precompiles overrides into template files"
   task :precompile => [:environment, :clean] do |t, args|
-    base_path = Rails.root.join("app/compiled_views")
-
-    # temporarily configures deface env and loads
-    # all overrides so we can precompile
-    unless Rails.application.config.deface.enabled
-      Rails.application.config.deface = Deface::Environment.new
-      Rails.application.config.deface.overrides.early_check
-      Rails.application.config.deface.overrides.load_all Rails.application
-    end
-
-    Rails.application.config.deface.overrides.all.each do |virtual_path,overrides|
-      template_path = base_path.join( "#{virtual_path}.html.erb")
-
-      FileUtils.mkdir_p template_path.dirname
-      begin
-        source = load_template_source(virtual_path.to_s, false, true)
-        if source.blank?
-          raise "Compiled source was blank for '#{virtual_path}'"
-        end
-        File.open(template_path, 'w') {|f| f.write source } 
-      rescue Exception => e
-        puts "Unable to precompile '#{virtual_path}' due to: "
-        puts e.message
-      end
-    end
+    Deface::Precompiler.precompile()
   end
 
   desc "Removes all precompiled override templates"


### PR DESCRIPTION
This is the first of many pull requests as we are hoping to provide some hooks into deface for extensibility.  

In particular, we are actively working on support mutli-tenant deface.

This commit allows us to override the precompile so that we can have tenant-specific compiled views.
