### PR TITLE
tightens up the haml dependeny in the gemspec (disallows haml 4)

### DIFF
--- a/deface.gemspec
+++ b/deface.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('colorize', '>= 0.5.8')
 
   s.add_development_dependency('rspec', '>= 2.11.0')
-  s.add_development_dependency('haml', '>= 3.1.4')
+  s.add_development_dependency('haml', '~> 3.1.4')
   s.add_development_dependency('simplecov', '>= 0.6.4')
   s.add_development_dependency('generator_spec', '~> 0.8.5')
 end


### PR DESCRIPTION
Hi Brian,

I'm convinced that if you were to trigger the travis hooks in master that all the tests would fail, as haml 4 will be brought in, instead of the 3.1 series.

This is the reason my other pull requeest https://github.com/spree/deface/pull/78 is failing.

This took me a while to figure out as I'm not a gemspec guru (yet), but I'm fairly certain this is the case.

In this commit, I have tightened up the constraint to keep us < haml 4.

Haml 4 gives us a railtie error, at least in the specs (it is easy enough to reproduce as I'm sure you are aware).
