### PR TITLE
mock is deprecated. Use double instead.

### DIFF
--- a/spec/deface/dsl/context_spec.rb
+++ b/spec/deface/dsl/context_spec.rb
@@ -37,7 +37,7 @@ describe Deface::DSL::Context do
       it 'should generate a warning if two action values are specified' do
         subject.insert_top('selector')
 
-        logger = mock('logger')
+        logger = double('logger')
         Rails.should_receive(:logger).and_return(logger)
         logger.should_receive(:error).with("\e[1;32mDeface: [WARNING]\e[0m Multiple action methods have been called. The last one will be used.")
 
@@ -67,7 +67,7 @@ describe Deface::DSL::Context do
       it 'should generate a warning if two sources are specified' do
         subject.partial('partial name')
 
-        logger = mock('logger')
+        logger = double('logger')
         Rails.should_receive(:logger).and_return(logger)
         logger.should_receive(:error).with("\e[1;32mDeface: [WARNING]\e[0m Multiple source methods have been called. The last one will be used.")
 

--- a/spec/deface/dsl/loader_spec.rb
+++ b/spec/deface/dsl/loader_spec.rb
@@ -6,7 +6,7 @@ describe Deface::DSL::Loader do
   context '.load' do
     context 'extension check' do
       it 'should succeed if file ends with .deface' do
-        file = mock('deface file')
+        file = double('deface file')
         filename = 'app/overrides/example_name.deface'
 
         lambda { Deface::DSL::Loader.load(filename) }.should_not raise_error(
@@ -14,7 +14,7 @@ describe Deface::DSL::Loader do
       end
 
       it 'should succeed if file ends with .html.erb.deface' do
-        file = mock('deface file')
+        file = double('deface file')
         filename = 'app/overrides/example_name.html.erb.deface'
 
         lambda { Deface::DSL::Loader.load(filename) }.should_not raise_error(
@@ -22,7 +22,7 @@ describe Deface::DSL::Loader do
       end
 
       it 'should succeed if file ends with .html.haml.deface' do
-        file = mock('deface file')
+        file = double('deface file')
         filename = 'app/overrides/example_name.html.haml.deface'
 
         lambda { Deface::DSL::Loader.load(filename) }.should_not raise_error(
@@ -30,7 +30,7 @@ describe Deface::DSL::Loader do
       end
 
       it 'should succeed if file ends with .html.slim.deface' do
-        file = mock('deface file')
+        file = double('deface file')
         filename = 'app/overrides/example_name.html.slim.deface'
 
         lambda { Deface::DSL::Loader.load(filename) }.should_not raise_error(
@@ -38,7 +38,7 @@ describe Deface::DSL::Loader do
       end
 
       it 'should fail if file ends with .blargh.deface' do
-        file = mock('deface file')
+        file = double('deface file')
         filename = 'app/overrides/example_name.blargh.deface'
 
         lambda { Deface::DSL::Loader.load(filename) }.should raise_error(
@@ -46,7 +46,7 @@ describe Deface::DSL::Loader do
       end
 
       it "should suceed if parent directory has a dot(.) in it's name" do
-        file = mock('deface file')
+        file = double('deface file')
         filename = 'app/overrides/parent.dir.with.dot/example_name.html.haml.deface'
 
         lambda { Deface::DSL::Loader.load(filename) }.should_not raise_error(
@@ -55,7 +55,7 @@ describe Deface::DSL::Loader do
     end
 
     it 'should fail if .html.erb.deface file is in the root of app/overrides' do
-      file = mock('html/erb/deface file')
+      file = double('html/erb/deface file')
       filename = 'app/overrides/example_name.html.erb.deface'
 
       lambda { Deface::DSL::Loader.load(filename) }.should raise_error(
@@ -63,16 +63,16 @@ describe Deface::DSL::Loader do
     end
 
     it 'should set the virtual_path for a .deface file in a directory below overrides' do
-      file = mock('deface file')
+      file = double('deface file')
       filename = 'app/overrides/path/to/view/example_name.deface'
       File.should_receive(:open).with(filename).and_yield(file)
 
       override_name = 'example_name'
-      context = mock('dsl context')
+      context = double('dsl context')
       Deface::DSL::Context.should_receive(:new).with(override_name).
         and_return(context)
 
-      file_contents = mock('file contents')
+      file_contents = double('file contents')
       file.should_receive(:read).and_return(file_contents)
 
       context.should_receive(:virtual_path).with('path/to/view').ordered
@@ -83,16 +83,16 @@ describe Deface::DSL::Loader do
     end
 
     it 'should set the virtual_path for a .html.erb.deface file in a directory below overrides' do
-      file = mock('html/erb/deface file')
+      file = double('html/erb/deface file')
       filename = 'app/overrides/path/to/view/example_name.html.erb.deface'
       File.should_receive(:open).with(filename).and_yield(file)
 
       override_name = 'example_name'
-      context = mock('dsl context')
+      context = double('dsl context')
       Deface::DSL::Context.should_receive(:new).with(override_name).
         and_return(context)
 
-      file_contents = mock('file contents')
+      file_contents = double('file contents')
       file.should_receive(:read).and_return(file_contents)
 
       Deface::DSL::Loader.should_receive(:extract_dsl_commands_from_erb).
@@ -108,16 +108,16 @@ describe Deface::DSL::Loader do
     end
 
     it 'should set the virtual_path for a .html.haml.deface file in a directory below overrides' do
-      file = mock('html/haml/deface file')
+      file = double('html/haml/deface file')
       filename = 'app/overrides/path/to/view/example_name.html.haml.deface'
       File.should_receive(:open).with(filename).and_yield(file)
 
       override_name = 'example_name'
-      context = mock('dsl context')
+      context = double('dsl context')
       Deface::DSL::Context.should_receive(:new).with(override_name).
         and_return(context)
 
-      file_contents = mock('file contents')
+      file_contents = double('file contents')
       file.should_receive(:read).and_return(file_contents)
 
       Deface::DSL::Loader.should_receive(:extract_dsl_commands_from_haml).
@@ -133,16 +133,16 @@ describe Deface::DSL::Loader do
     end
 
     it 'should set the virtual_path for a .html.slim.deface file in a directory below overrides' do
-      file = mock('html/slim/deface file')
+      file = double('html/slim/deface file')
       filename = 'app/overrides/path/to/view/example_name.html.slim.deface'
       File.should_receive(:open).with(filename).and_yield(file)
 
       override_name = 'example_name'
-      context = mock('dsl context')
+      context = double('dsl context')
       Deface::DSL::Context.should_receive(:new).with(override_name).
         and_return(context)
 
-      file_contents = mock('file contents')
+      file_contents = double('file contents')
       file.should_receive(:read).and_return(file_contents)
 
       Deface::DSL::Loader.should_receive(:extract_dsl_commands_from_slim).

--- a/spec/deface/environment_spec.rb
+++ b/spec/deface/environment_spec.rb
@@ -54,7 +54,7 @@ module Deface
         end
 
         it "should enumerate_and_load nil when railtie has no app/overrides path set" do
-          Rails.application.stub_chain :railties, railties_collection_accessor => [mock('railtie', :root => "/some/path")]
+          Rails.application.stub_chain :railties, railties_collection_accessor => [double('railtie', :root => "/some/path")]
 
           Rails.application.config.deface.overrides.should_receive(:enumerate_and_load).with(nil, Rails.application.root)
           Rails.application.config.deface.overrides.should_receive(:enumerate_and_load).with(nil, "/some/path")
@@ -62,7 +62,7 @@ module Deface
         end
 
         it "should enumerate_and_load path when railtie has app/overrides path set" do
-          Rails.application.stub_chain :railties, railties_collection_accessor => [ mock('railtie', :root => "/some/path", :paths => {"app/overrides" => ["app/some_path"] } )]
+          Rails.application.stub_chain :railties, railties_collection_accessor => [ double('railtie', :root => "/some/path", :paths => {"app/overrides" => ["app/some_path"] } )]
 
           Rails.application.config.deface.overrides.should_receive(:enumerate_and_load).with(nil, Rails.application.root)
           Rails.application.config.deface.overrides.should_receive(:enumerate_and_load).with(["app/some_path"] , "/some/path")
@@ -70,7 +70,7 @@ module Deface
         end
 
         it "should enumerate_and_load railties first, followed by the application iteslf" do
-          Rails.application.stub_chain :railties, railties_collection_accessor => [ mock('railtie', :root => "/some/path", :paths => {"app/overrides" => ["app/some_path"] } )]
+          Rails.application.stub_chain :railties, railties_collection_accessor => [ double('railtie', :root => "/some/path", :paths => {"app/overrides" => ["app/some_path"] } )]
 
           Rails.application.config.deface.overrides.should_receive(:enumerate_and_load).with(["app/some_path"] , "/some/path").ordered
           Rails.application.config.deface.overrides.should_receive(:enumerate_and_load).with(nil, Rails.application.root).ordered
@@ -78,7 +78,7 @@ module Deface
         end
 
         it "should ignore railtie with no root" do
-          railtie = mock('railtie')
+          railtie = double('railtie')
           Rails.application.stub_chain :railties, railties_collection_accessor => [railtie]
 
           railtie.should_receive(:respond_to?).with(:root)
@@ -96,7 +96,7 @@ module Deface
 
       describe 'load_overrides' do
         let(:assets_path) { Pathname.new(File.join(File.dirname(__FILE__), '..', "assets")) }
-        let(:engine) { mock('railtie', :root => assets_path, :class => "DummyEngine", :paths => {"app/overrides" => ["dummy_engine"]}) }
+        let(:engine) { double('railtie', :root => assets_path, :class => "DummyEngine", :paths => {"app/overrides" => ["dummy_engine"]}) }
         before { Rails.application.stub(:class => 'RailsAppl') }
 
         it "should keep a reference to which railtie/app defined the override" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,13 +44,13 @@ shared_context "mock Rails" do
 
     # mock rails to keep specs FAST!
     unless defined? Rails
-      Rails = mock 'Rails'
+      Rails = double 'Rails'
     end
 
     Rails.stub :version => rails_version
 
-    Rails.stub :application => mock('application')
-    Rails.application.stub :config => mock('config')
+    Rails.stub :application => double('application')
+    Rails.application.stub :config => double('config')
     Rails.application.config.stub :cache_classes => true
     Rails.application.config.stub :deface => ActiveSupport::OrderedOptions.new
     Rails.application.config.deface.enabled = true
@@ -61,13 +61,13 @@ shared_context "mock Rails" do
 
     Rails.stub :root => Pathname.new('spec/dummy')
 
-    Rails.stub :logger => mock('logger')
+    Rails.stub :logger => double('logger')
     Rails.logger.stub(:error)
     Rails.logger.stub(:warning)
     Rails.logger.stub(:info)
     Rails.logger.stub(:debug)
 
-    Time.stub :zone => mock('zone')
+    Time.stub :zone => double('zone')
     Time.zone.stub(:now).and_return Time.parse('1979-05-25')
 
     require "haml/template/plugin"


### PR DESCRIPTION
Running tests results in tons of

```
DEPRECATION: mock is deprecated. Use double instead.
```

Relevant parts of bundle show

```
* rspec (2.14.1)
* rspec-core (2.14.5)
* rspec-expectations (2.14.2)
* rspec-mocks (2.14.3)
```
