### PR TITLE
Loosen generators_spec dependency version

### DIFF
--- a/deface.gemspec
+++ b/deface.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('haml', '>= 3.1.4')
   s.add_development_dependency('slim', '>= 2.0.0')
   s.add_development_dependency('simplecov', '>= 0.6.4')
-  s.add_development_dependency('generator_spec', '~> 0.8.5')
+  s.add_development_dependency('generator_spec', '~> 0.8')
 end


### PR DESCRIPTION
So we can bundle dependencies on both Rails 3 and 4
