### PR TITLE
Replace colorize gem with rainbow

### DIFF
--- a/deface.gemspec
+++ b/deface.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('nokogiri', '~> 1.6.0')
   s.add_dependency('rails', '>= 4.1')
-  s.add_dependency('colorize', '>= 0.5.8')
+  s.add_dependency('console-colors', '>= 0.0.2')
   s.add_dependency('polyglot')
 
   s.add_development_dependency('appraisal')

--- a/deface.gemspec
+++ b/deface.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('nokogiri', '~> 1.6.0')
   s.add_dependency('rails', '>= 4.1')
-  s.add_dependency('console-colors', '>= 0.0.2')
+  s.add_dependency('rainbow', '>= 2.1.0')
   s.add_dependency('polyglot')
 
   s.add_development_dependency('appraisal')

--- a/lib/deface.rb
+++ b/lib/deface.rb
@@ -36,7 +36,6 @@ require "deface/matchers/element"
 require "deface/matchers/range"
 require "deface/environment"
 require "deface/precompiler"
-require "console-colors"
 
 module Deface
   if defined?(Rails)

--- a/lib/deface.rb
+++ b/lib/deface.rb
@@ -36,7 +36,7 @@ require "deface/matchers/element"
 require "deface/matchers/range"
 require "deface/environment"
 require "deface/precompiler"
-require "colorize"
+require "console-colors"
 
 module Deface
   if defined?(Rails)

--- a/lib/deface/utils/failure_finder.rb
+++ b/lib/deface/utils/failure_finder.rb
@@ -1,3 +1,5 @@
+require 'rainbow'
+
 module Deface
   module Utils
     module FailureFinder
@@ -28,9 +30,9 @@ module Deface
 
         fails.each do |override|
           if override.failure.nil?
-            puts " '#{override.name}' reported no failures".green
+            puts Rainbow(" '#{override.name}' reported no failures").green
           else
-            puts " '#{override.name}' #{override.failure}".red
+            puts Rainbow(" '#{override.name}' #{override.failure}").red
           end
         end
 

--- a/tasks/utils.rake
+++ b/tasks/utils.rake
@@ -1,6 +1,6 @@
 require 'deface'
 require 'deface/utils/failure_finder'
-require 'console-colors'
+require 'rainbow'
 
 namespace :deface do
   include Deface::TemplateHelper
@@ -68,10 +68,10 @@ namespace :deface do
     end
 
     if fail_count == 0
-      puts "\nEverything's looking good!".green
+      puts Rainbow("\nEverything's looking good!").green
       exit(0)
     else
-      puts "\nYou had a total of #{fail_count} failures.".red
+      puts Rainbow("\nYou had a total of #{fail_count} failures.").red
       exit(1)
     end
   end

--- a/tasks/utils.rake
+++ b/tasks/utils.rake
@@ -1,6 +1,6 @@
 require 'deface'
 require 'deface/utils/failure_finder'
-require 'colorize'
+require 'console-colors'
 
 namespace :deface do
   include Deface::TemplateHelper


### PR DESCRIPTION
The colorize gem is licensed under GPL v2. While I sympathize with the
goal of the copyleft licenses, including library code that's licensed
under GPL can cause legal headaches. The rainbow gem seems to do
the same thing, except with an MIT license.

If replacing a GPL dependency with an MIT one isn't preferred, perhaps:
1. Remove the 2 calls to `.green` and 2 calls to `.red`, or
2. Use another gem's capability like [bundler][bundler]
3. Implement the red and green in this codebase

[bundler]:
https://github.com/bundler/bundler/blob/20f04aa8923c0d0f02e7a74d5e9609d772351668/lib/bundler/vendor/thor/lib/thor/shell/color.rb
