### PR TITLE
Default 'name' attr to caller's filename and line number

### DIFF
--- a/lib/deface/override.rb
+++ b/lib/deface/override.rb
@@ -26,6 +26,16 @@ module Deface
         return
       end
 
+      # If no name was specified, use the filename and line number of the caller
+      # Including the line number ensure unique names if multiple overrides
+      # are defined in the same file
+      unless args.key? :name
+        parts = caller[0].split(':')
+        file_name = File.basename(parts[0], '.rb')
+        line_number = parts[1]
+        args[:name] = "#{file_name}_#{line_number}"
+      end
+
       raise(ArgumentError, ":name must be defined") unless args.key? :name
       raise(ArgumentError, ":virtual_path must be defined") if args[:virtual_path].blank?
 

--- a/spec/deface/override_spec.rb
+++ b/spec/deface/override_spec.rb
@@ -100,6 +100,22 @@ module Deface
           Deface::Override.new(:virtual_path => "posts/new", :name => "Posts#new", :replace => "h1", :text => "<h1>argh!</h1>")
         }.to change{Deface::Override.all.size}.by(1)
       end
+
+      it "should default :name when none is given" do
+        override = Deface::Override.new(:virtual_path => "posts/new", :replace => "h1", :text => "<h1>Derp!</h1>")
+        expect(override.name).not_to be_empty
+      end
+
+      it "should default :name to caller's file name and a line number" do
+        override = Deface::Override.new(:virtual_path => "posts/new", :replace => "h1", :text => "<h1>Derp!</h1>")
+        expect(override.name).to match Regexp.new("#{Regexp.escape(File.basename(__FILE__, '.rb'))}_\\d+")
+      end
+
+      it "should use :name argument when given" do
+        name = "Posts#new"
+        override = Deface::Override.new(:virtual_path => "posts/new", :name => name, :replace => "h1", :text => "<h1>Derp!</h1>")
+        expect(override.name).to eq(name)
+      end
     end
 
     describe "with :text" do


### PR DESCRIPTION
A well-named override will typically describe what it's doing in the file name itself. Specifying the 'name' parameter in such cases is redundant and can be done automatically by the initializer.

Example:

Given the file `app/overrides/remove_h1_from_products_index.rb`, the `name` of the `Deface::Override` would default to `remove_h1_from_products_index_NN` where `NN` is the line number on which the initializer is called.
