### PR TITLE
fix tests for updated haml version(5.0.1+)

### DIFF
--- a/lib/deface/haml_converter.rb
+++ b/lib/deface/haml_converter.rb
@@ -20,7 +20,7 @@ module Deface
     def parse_old_attributes(line)
       attributes_hash, rest, last_line = super(line)
 
-      attributes_hash = deface_attributes(attributes_hash)
+      attributes_hash = "{#{deface_attributes(attributes_hash)}}"
 
       return attributes_hash, rest, last_line
     end
@@ -34,7 +34,6 @@ module Deface
       return attributes, rest, last_line
     end
     private
-
       # coverts { attributes into deface compatibily attributes
       def deface_attributes(attrs)
         return if attrs.nil?

--- a/spec/deface/haml_converter_spec.rb
+++ b/spec/deface/haml_converter_spec.rb
@@ -20,22 +20,22 @@ module Deface
     %h2 Welcome to our site!
     %p= print_information
   .right.column
-    = render :partial => "sidebar"})).to eq("<div id='content'>  <div class='left column'>    <h2>Welcome to our site!</h2>    <p>    <%= print_information %></p>  </div>  <div class='right column'>    <%= render :partial => \"sidebar\" %>  </div></div>")
+    = render :partial => "sidebar"})).to eq("<div id='content'><div class='left column'><h2>Welcome to our site!</h2><p><%= print_information %></p></div><div class='right column'><%= render :partial => \"sidebar\" %></div></div>")
       end
 
       it "should handle simple haml attributes" do
-        expect(haml_to_erb("%meta{:charset => 'utf-8'}")).to eq("<meta charset='utf-8' />")
+        expect(haml_to_erb("%meta{:charset => 'utf-8'}")).to eq("<meta charset='utf-8'>")
         expect(haml_to_erb("%p(alt='hello world')Hello World!")).to eq("<p alt='hello world'>Hello World!</p>")
       end
 
       it "should handle haml attributes with commas" do
-        expect(haml_to_erb("%meta{'http-equiv' => 'X-UA-Compatible', :content => 'IE=edge,chrome=1'}")).to eq("<meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible' />")
-        expect(haml_to_erb("%meta(http-equiv='X-UA-Compatible' content='IE=edge,chrome=1')")).to eq("<meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible' />")
-        expect(haml_to_erb('%meta{:name => "author", :content => "Example, Inc."}')).to eq("<meta content='Example, Inc.' name='author' />")
-        expect(haml_to_erb('%meta(name="author" content="Example, Inc.")')).to eq("<meta content='Example, Inc.' name='author' />")
+        expect(haml_to_erb("%meta{'http-equiv' => 'X-UA-Compatible', :content => 'IE=edge,chrome=1'}")).to eq("<meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible'>")
+        expect(haml_to_erb("%meta(http-equiv='X-UA-Compatible' content='IE=edge,chrome=1')")).to eq("<meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible'>")
+        expect(haml_to_erb('%meta{:name => "author", :content => "Example, Inc."}')).to eq("<meta content='Example, Inc.' name='author'>")
+        expect(haml_to_erb('%meta(name="author" content="Example, Inc.")')).to eq("<meta content='Example, Inc.' name='author'>")
 
         if RUBY_VERSION > "1.9"
-          expect(haml_to_erb('%meta{name: "author", content: "Example, Inc."}')).to eq("<meta content='Example, Inc.' name='author' />")
+          expect(haml_to_erb('%meta{name: "author", content: "Example, Inc."}')).to eq("<meta content='Example, Inc.' name='author'>")
         end
       end
 
@@ -73,7 +73,7 @@ module Deface
       it "should handle blocks passed to erb loud" do
         expect(haml_to_erb("= form_for Post.new do |f|
   %p
-    = f.text_field :name")).to eq("<%= form_for Post.new do |f| %><p>  <%= f.text_field :name %></p><% end %>")
+    = f.text_field :name")).to eq("<%= form_for Post.new do |f| %><p><%= f.text_field :name %></p><% end %>")
 
       end
 
@@ -81,7 +81,7 @@ module Deface
        it "should handle blocks passed to erb silent" do
         expect(haml_to_erb("- @posts.each do |post|
   %p
-    = post.name")).to eq("<% @posts.each do |post| %><p>  <%= post.name %></p><% end %>")
+    = post.name")).to eq("<% @posts.each do |post| %><p><%= post.name %></p><% end %>")
 
       end
     end

--- a/spec/deface/override_spec.rb
+++ b/spec/deface/override_spec.rb
@@ -152,7 +152,7 @@ module Deface
       end
 
       it "should return erb converted from haml as source" do
-        expect(@override.source).to eq("<strong class='erb' id='message'><%= 'Hello, World!' %>\n</strong>\n")
+        expect(@override.source).to eq("<strong class='erb' id='message'><%= 'Hello, World!' %></strong>\n")
 
         expect(@override.source_argument).to eq(:haml)
       end

--- a/spec/deface/template_helper_spec.rb
+++ b/spec/deface/template_helper_spec.rb
@@ -17,7 +17,7 @@ module Deface
         end
 
         it "should return converted source for partial containing haml" do
-          expect(load_template_source("shared/hello", true)).to eq "<div class='<%= @some %>' id='message'><%= 'Hello, World!' %>\n</div>\n"
+          expect(load_template_source("shared/hello", true)).to eq "<div class='<%= @some %>' id='message'><%= 'Hello, World!' %></div>\n"
         end
 
         it "should return converted source for partial containing slim" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,7 @@ shared_context "mock Rails" do
     allow(Time).to receive(:zone).and_return double('zone')
     allow(Time.zone).to receive(:now).and_return Time.parse('1979-05-25')
 
-    require "haml/template/plugin"
+    require "haml/template"
     require 'slim/erb_converter'
   end
 end


### PR DESCRIPTION
Tests started breaking when the haml version was bumped in this PR #171

This PR fixes the broken tests considering haml 5.0.1 as a baseline.