### PR TITLE
Do not modify frozen eager_load_paths Array

### DIFF
--- a/lib/deface/railtie.rb
+++ b/lib/deface/railtie.rb
@@ -36,7 +36,7 @@ module Deface
     initializer "deface.tweak_eager_loading", :before => :set_load_path do |app|
 
       # application
-      app.config.eager_load_paths.reject! {|path| path.to_s  =~ /app\/overrides\z/ }
+      app.config.eager_load_paths = app.config.eager_load_paths.reject { |path| path.to_s  =~ /app\/overrides\z/ }
 
       # railites / engines / extensions
       railties = if Rails.version >= "4.0"
@@ -47,7 +47,7 @@ module Deface
 
       railties.each do |railtie|
         next unless railtie.respond_to?(:root) && railtie.config.respond_to?(:eager_load_paths)
-        railtie.config.eager_load_paths.reject! {|path| path.to_s  =~ /app\/overrides\z/ }
+        railtie.config.eager_load_paths = railtie.config.eager_load_paths.reject { |path| path.to_s  =~ /app\/overrides\z/ }
       end
     end
 


### PR DESCRIPTION
When one does not change `config.auto_load_paths` in the
host app, by the time the `deface.tweak_eager_loading` initializer
runs, `{app,railtie}.config.eager_load_paths` is [frozen](1).

Running `reject!` on a frozen Array results in an error, preventing
the host app from starting.

This commit modifies the initializer such that instead of modifying the
array, it is replaced by the modified array, preventing this error.

[1]: https://github.com/rails/rails/blob/master/railties/lib/rails/engine.rb#L573