### PR TITLE
Allow to bundle nokogiri greater than 1.6

### DIFF
--- a/deface.gemspec
+++ b/deface.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "Deface is a library that allows you to customize ERB, Haml and Slim views in Rails"
 
-  s.add_dependency('nokogiri', '~> 1.6')
+  s.add_dependency('nokogiri', '>= 1.6')
   s.add_dependency('rails', '>= 4.1')
   s.add_dependency('rainbow', '>= 2.1.0')
   s.add_dependency('polyglot')


### PR DESCRIPTION
Older versions of nokogiri can be vulnerable to http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9050

As such, it's desirable to be able to use latest version of nokogiri with deface.