### PR TITLE
Support for configurable hash digest algorithm

### DIFF
--- a/lib/deface.rb
+++ b/lib/deface.rb
@@ -4,6 +4,7 @@ require "deface/template_helper"
 require "deface/original_validator"
 require "deface/applicator"
 require "deface/search"
+require "deface/digest"
 require "deface/override"
 require "deface/parser"
 require "deface/dsl/loader"
@@ -40,6 +41,10 @@ require "deface/precompiler"
 module Deface
   if defined?(Rails)
     require "deface/railtie"
+  end
+
+  if defined?(ActiveSupport::Digest)
+    Deface::Digest.digest_class = ActiveSupport::Digest
   end
 
   # Exceptions

--- a/lib/deface/action_view_extensions.rb
+++ b/lib/deface/action_view_extensions.rb
@@ -52,7 +52,7 @@ ActionView::Template.class_eval do
       deface_hash = Deface::Override.digest(:virtual_path => @virtual_path)
 
       #we digest the whole method name as if it gets too long there's problems
-      "_#{Digest::MD5.new.update("#{deface_hash}_#{method_name_without_deface}").hexdigest}"
+      "_#{Deface::Digest.hexdigest("#{deface_hash}_#{method_name_without_deface}")}"
     end
 
   private

--- a/lib/deface/digest.rb
+++ b/lib/deface/digest.rb
@@ -1,0 +1,25 @@
+module Deface
+  class Digest
+    class <<self
+      def digest_class
+        @digest_class || ::Digest::MD5
+      end
+
+      def digest_class=(klass)
+        @digest_class = klass
+      end
+
+      def hexdigest(arg)
+        new.hexdigest(arg)
+      end
+    end
+
+    def initialize(klass = nil)
+      @digest_class = klass || self.class.digest_class
+    end
+
+    def hexdigest(arg)
+      @digest_class.hexdigest(arg).truncate(32)
+    end
+  end
+end

--- a/lib/deface/original_validator.rb
+++ b/lib/deface/original_validator.rb
@@ -11,7 +11,7 @@ module Deface
     def validate_original(match)
       match = match.map(&:to_s).join if match.is_a? Array
 
-      hashed_original = Digest::SHA1.hexdigest(match.to_s.gsub(/\s/, ''))
+      hashed_original = ::Digest::SHA1.hexdigest(match.to_s.gsub(/\s/, ''))
 
       if @args[:original].present?
         valid = @args[:original] == hashed_original

--- a/lib/deface/override.rb
+++ b/lib/deface/override.rb
@@ -185,7 +185,8 @@ module Deface
     # used to determine if an override has changed
     #
     def digest
-      Digest::MD5.new.update(@args.keys.map(&:to_s).sort.concat(@args.values.map(&:to_s).sort).join).hexdigest
+      to_hash = @args.keys.map(&:to_s).sort.concat(@args.values.map(&:to_s).sort).join
+      Deface::Digest.hexdigest(to_hash)
     end
 
     # Creates MD5 of all overrides that apply to a particular
@@ -195,8 +196,8 @@ module Deface
     #
     def self.digest(details)
       overrides = self.find(details)
-
-      Digest::MD5.new.update(overrides.inject('') { |digest, override| digest << override.digest }).hexdigest
+      to_hash = overrides.inject('') { |digest, override| digest << override.digest }
+      Deface::Digest.hexdigest(to_hash)
     end
 
     def self.all

--- a/spec/deface/digest_spec.rb
+++ b/spec/deface/digest_spec.rb
@@ -1,0 +1,24 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+module Deface
+  describe Digest do
+    it "should use MD5 by default" do
+      expect(Digest.new.hexdigest("123")).to eq "202cb962ac59075b964b07152d234b70"
+    end
+
+    it "should use user-provided digest" do
+      digest = double("digest")
+      expect(digest).to receive(:hexdigest).with("to_digest").and_return("digested")
+      expect(Digest.new(digest).hexdigest("to_digest")).to eq "digested"
+    end
+
+    it "should truncate digest to 32 characters" do
+      digest = double("digest")
+      expect(digest).to receive(:hexdigest).with("to_digest").and_return("a" * 50)
+      expect(Digest.new(digest).hexdigest("to_digest").size).to eq 32
+    end
+  end
+end
+


### PR DESCRIPTION
Relies on ActiveSupport::Digest class introduced in Rails 5.2. This is useful when running in FIPS-compatible environments where MD5 hash isn't available.

Please note I left ```Deface::OriginalValidator#validate_original``` as is, as by default ```ActiveSupport::Digest``` is configured to use MD5, which may not be sufficient in this case.