### PR TITLE
Memory allocations

### DIFF
--- a/lib/deface/override.rb
+++ b/lib/deface/override.rb
@@ -196,7 +196,7 @@ module Deface
     #
     def self.digest(details)
       overrides = self.find(details)
-      to_hash = overrides.inject('') { |digest, override| digest << override.digest }
+      to_hash = overrides.map(&:digest).join
       Deface::Digest.hexdigest(to_hash)
     end
 

--- a/lib/deface/search.rb
+++ b/lib/deface/search.rb
@@ -10,12 +10,15 @@ module Deface
         virtual_path = details[:virtual_path].dup
         return [] if virtual_path.nil?
 
-        [/^\//, /\.\w+\z/].each { |regex| virtual_path.gsub!(regex, '') }
+        [/^\//, /\.\w+\z/].each { |regex| virtual_path.gsub!(regex, ''.freeze) }
 
         result = []
         result << self.all[virtual_path.to_sym].try(:values)
+        
+        result = result.flatten
+        result.compact!
 
-        result.flatten.compact.sort_by &:sequence
+        result.sort_by &:sequence
       end
 
       # finds all overrides that are using a template / parital as there source


### PR DESCRIPTION
I've noticed a peak of memory allocations in this file by using `derailed` gem

```
       800  /Users/progm/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/deface-1.0.2/lib/deface/search.rb:13
       400  /Users/progm/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/deface-1.0.2/lib/deface/override.rb:189
```

That could be simply fixed using a `.freeze`.

* Freezing empty strings
* use `compact!` instead of compact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal logic for combining digest strings and processing search results, resulting in cleaner and more efficient code execution. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->