### PR TITLE
Override `ActionView::Template::Handlers::ERB:Erubi` initialize method to set `@output_buffer`

### DIFF
--- a/core/config/initializers/action_view.rb
+++ b/core/config/initializers/action_view.rb
@@ -1,0 +1,22 @@
+module ActionView
+  class Template
+    module Handlers
+      class ERB
+        class Erubi < ::Erubi::Engine
+          def initialize(input, properties = {})
+            @newline_pending = 0
+
+            # Dup properties so that we don't modify argument
+            properties = Hash[properties]
+            properties[:preamble]   = "@output_buffer = output_buffer || ActionView::OutputBuffer.new;"
+            properties[:postamble]  = "@output_buffer.to_s"
+            properties[:bufvar]     = "@output_buffer"
+            properties[:escapefunc] = ""
+
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Problem created by, I guess, these two PR's on Rails
https://github.com/rails/rails/commit/ec5c946138f63dc975341d6521587adc74f6b441
https://github.com/rails/rails/commit/ccfa01c36e79013881ffdb7ebe397cec733d15b2#diff-dfb6e0314ad9639bab460ea64871aa47R27