### PR TITLE
Fix typo virutal_path -> virtual_path

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -116,7 +116,7 @@ You should save your overrides in the ````app/overrides````, normally one overri
 * <tt>:sequence</tt> - Used to order the application of an override for a specific virtual path, helpful when an override depends on another override being applied first, supports:
   * <tt>:sequence => n</tt> - where n is a positive or negative integer (lower numbers get applied first, default 100).
   * <tt>:sequence => {:before => "*override_name*"}</tt> - where "*override_name*" is the name of an override defined for the 
-                                              same virutal_path, the current override will be appplied before 
+                                              same virtual_path, the current override will be appplied before 
                                               the named override passed.
   * <tt>:sequence => {:after => "*override_name*"}</tt> - the current override will be applied after the named override passed.
 


### PR DESCRIPTION
Fix typo in README