### PR TITLE
Fix prefixed attribute parsing

### DIFF
--- a/lib/deface/haml_converter.rb
+++ b/lib/deface/haml_converter.rb
@@ -37,6 +37,7 @@ module Deface
       # coverts { attributes into deface compatibily attributes
       def deface_attributes(attrs)
         return if attrs.nil?
+        return attrs if attrs.scan(/\{/).count > 1
 
         attrs.gsub! /\{|\}/, ''
 

--- a/spec/deface/haml_converter_spec.rb
+++ b/spec/deface/haml_converter_spec.rb
@@ -28,6 +28,16 @@ module Deface
         expect(haml_to_erb("%p(alt='hello world')Hello World!")).to eq("<p alt='hello world'>Hello World!</p>")
       end
 
+      it "should handle recursive attributes" do
+        expect(haml_to_erb("%div{:data => {:foo => 'bar'}}")).to eq("<div data-foo='bar'></div>")
+        expect(haml_to_erb("%div{:data => {:foo => { :bar => 'baz' }, :qux => 'corge'}}")).to eq("<div data-foo-bar='baz' data-qux='corge'></div>")
+
+        if RUBY_VERSION > "1.9"
+          expect(haml_to_erb("%div{data: {foo: 'bar'}}")).to eq("<div data-foo='bar'></div>")
+          expect(haml_to_erb("%div{data: {foo: { bar: 'baz' }, qux: 'corge'}}")).to eq("<div data-foo-bar='baz' data-qux='corge'></div>")
+        end
+      end
+
       it "should handle haml attributes with commas" do
         expect(haml_to_erb("%meta{'http-equiv' => 'X-UA-Compatible', :content => 'IE=edge,chrome=1'}")).to eq("<meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible' />")
         expect(haml_to_erb("%meta(http-equiv='X-UA-Compatible' content='IE=edge,chrome=1')")).to eq("<meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible' />")


### PR DESCRIPTION
This may be a less-than-ideal fix for this problem, but at least it's a starting point.

As hinted at in #196 (and originally in #172), due to the custom Haml parser that Deface introduces, recursive, prefixed attributes are not properly handled.

As a stopgap, in this PR I defer to the Haml parser for attributes whose values are found to have nested hashes.

Haml reference: http://haml.info/docs/yardoc/file.REFERENCE.html#prefixed-attributes