### PR TITLE
Remove updated_at from ActionView::Template#initialize in Rails 6

### DIFF
--- a/lib/deface/applicator.rb
+++ b/lib/deface/applicator.rb
@@ -48,8 +48,10 @@ module Deface
             end
           end
 
-          #prevents any caching by rails in development mode
-          details[:updated_at] = Time.now
+          if Rails.gem_version < Gem::Version.new('6.0.0')
+            #prevents any caching by rails in development mode
+            details[:updated_at] = Time.now
+          end
 
           source = doc.to_s
 

--- a/spec/deface/action_view_template_spec.rb
+++ b/spec/deface/action_view_template_spec.rb
@@ -43,8 +43,14 @@ module ActionView
         expect(@template.source).to eq("<%= raw(text) %>")
       end
 
-      it "should change updated_at" do
-        expect(@template.updated_at).to be > @updated_at
+      if Rails.gem_version >= Gem::Version.new('6.0.0')
+        it "should not change updated_at" do
+          expect(@template.updated_at).to eq(@updated_at)
+        end
+      else
+        it "should change updated_at" do
+          expect(@template.updated_at).to be > @updated_at
+        end
       end
     end
 


### PR DESCRIPTION
ActionView::Template#updated_at was deprecated in Rails 6 (https://github.com/rails/rails/pull/35623).