### PR TITLE
[Rails6.0/6.1] Avoid calling deprecated/removed method ActionView::Template#refresh

### DIFF
--- a/lib/deface/action_view_extensions.rb
+++ b/lib/deface/action_view_extensions.rb
@@ -41,7 +41,7 @@ module Deface::ActionViewExtensions
 
       if @compiled && !mod.instance_methods.include?(method_name.to_sym)
         @compiled = false
-        @source = refresh(view).source
+        @source = refresh(view).source if respond_to?(:refresh)
       end
       buffer.nil? ? super(view, locals, buffer, &block) : super(view, locals, **buffer, &block)
     end


### PR DESCRIPTION
related: https://github.com/spree/deface/issues/204

ActionView::Template#refresh:
* rails6.0: deprecated
* rails6.1: removed