### PR TITLE
Fix v1.8 with rails 6+

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,8 +5,12 @@ require 'rdoc/task'
 require 'rspec'
 require 'rspec/core/rake_task'
 
+require 'bundler'
+Bundler.require
+Bundler::GemHelper.install_tasks
+
 desc 'Default: run specs'
-task :default => :spec  
+task :default => :spec
 RSpec::Core::RakeTask.new do |t|
   t.pattern = "spec/**/*_spec.rb"
 end

--- a/lib/deface/action_view_extensions.rb
+++ b/lib/deface/action_view_extensions.rb
@@ -33,13 +33,19 @@ module Deface::ActionViewExtensions
         @handler = ActionView::Template::Handlers::ERB
 
         # Modify the existing string instead of returning a copy
-        @source.replace Deface::Override.apply_overrides(
+        new_source = Deface::Override.apply_overrides(
           Deface::Override.convert_source(source, syntax: syntax),
           overrides: overrides
         )
+
+        if Deface.before_rails_6?
+          @source.replace new_source
+        else
+          source.replace new_source
+        end
       end
 
-      @source
+      source
     end
 
     private


### PR DESCRIPTION
`@source` is actually holding a source reader and not a string in Rails 6+.

This problem was matched by the solidus_subscriptions specs https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_subscriptions/552/workflows/05c3c902-0cff-40b8-97b4-a493c086da08.