### PR TITLE
Fix warning string literal

### DIFF
--- a/lib/deface/dsl/loader.rb
+++ b/lib/deface/dsl/loader.rb
@@ -79,9 +79,12 @@ module Deface
           end
 
           comment.gsub('<!--', '').gsub('-->', '').strip.scan(/[^\s"']+|"[^"]*"|'[^']*'/).each do |part|
+            ends_with_quote = dsl_commands =~ /('|")\z/
+            starts_with_non_data_char = part =~ /\A[^\d:='"%]/
 
-            dsl_commands =~ /('|")\z/ || part =~ /\A[^\d:='"%]/ ? dsl_commands << "\n" : dsl_commands << ' '
-            dsl_commands << part
+            divider = ends_with_quote || starts_with_non_data_char ? "\n" : ' '
+
+            dsl_commands = [dsl_commands, divider, part].join('')
           end
 
           html_file_contents = html_file_contents.gsub(comment, '')


### PR DESCRIPTION
ref https://github.com/spree/deface/issues/240

After Ruby 3.4 upgrade, there is a new warning for `frozen string literal`. Refactor DSL command extraction to improve comment handling and formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of spacing and newlines when processing DSL commands extracted from HTML comments, resulting in more consistent formatting. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->